### PR TITLE
Add ts-config/paths to parse aliases correctly

### DIFF
--- a/backend/database/package.json
+++ b/backend/database/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "setUploadDirectory": "cd ./parser",
-    "upload": "doppler run -- ts-node ./parser/upload.ts"
+    "upload": "doppler run -- ts-node -r tsconfig-paths/register --files ./parser/uploadToDatabase.ts"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.171",

--- a/backend/database/parser/upload.ts
+++ b/backend/database/parser/upload.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import mongoose from 'mongoose';
+
 import path from 'path';
 
 import {isValidProblem, isValidProblemTemplateFiles} from './parser';
@@ -11,7 +11,7 @@ For each Problem
 - Update problem for each language template 
 */
 
-async function parseProblems() {
+export async function parseProblems(): Promise<void> {
   const rootFolder = 'problems';
 
   const problemNamesList = fs.readdirSync(rootFolder);
@@ -74,24 +74,3 @@ async function getUploadPromises(
   await Promise.all(uploadPromises);
   return uploadPromises;
 }
-
-mongoose.connect(
-  process.env.MONGO_URL,
-  {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useFindAndModify: false,
-  },
-  async (err) => {
-    if (err) console.log(err);
-    else {
-      console.log('MongoDB connected');
-      try {
-        await parseProblems();
-      } finally {
-        console.log('Server Closed');
-        mongoose.connection.close();
-      }
-    }
-  },
-);

--- a/backend/database/parser/uploadProblem.ts
+++ b/backend/database/parser/uploadProblem.ts
@@ -50,7 +50,8 @@ async function uploadProblemAndTemplate(
       new: true,
     };
 
-    const enumLanguage: ProgrammingLanguages = ProgrammingLanguages[language as ProgrammingLanguages];
+    const enumLanguage: ProgrammingLanguages =
+      ProgrammingLanguages[language as ProgrammingLanguages];
     const updateTemplateResult = await updateLanguageTemplate(
       codeSnippets,
       problemBO.problemTagsJson.title,

--- a/backend/database/parser/uploadToDatabase.ts
+++ b/backend/database/parser/uploadToDatabase.ts
@@ -1,0 +1,11 @@
+import {dbconnect} from '@mongoose';
+import {parseProblems} from './upload';
+
+async function uploadToDatabase() {
+  const connection = dbconnect();
+  await parseProblems();
+  connection.close();
+  console.log('Server Closed');
+}
+
+uploadToDatabase();

--- a/backend/database/tsconfig.json
+++ b/backend/database/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "target": "es6",
+    "target": "es2017",
     "composite": true,
     "alwaysStrict": true,
     "noImplicitReturns": true,
@@ -19,7 +19,8 @@
       "@problems/*": ["problems/*"],
       "@problems": ["problems"],
       "@mongoose/*": ["../server/src/initializers/mongoose/*"],
-      "@mongoose": ["../server/src/initializers/mongoose"]
+      "@mongoose": ["../server/src/initializers/mongoose"],
+      "@logger/*": ["../server/src/utils/logging/*"]
     }
   },
   "references": [{"path": "../server/tsconfig.json"}],


### PR DESCRIPTION
Add ts-config/paths to parse problem files with updating the alias imports

This removes the need to update file imports from `@mongoose` -> `mongoose` whenever we need to update our question database.

This works by using dbconnect() to connect to a mongoose instance and upload files to the same database used by the server when it's running.