### PR TITLE
Remove exit code check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
           command: docker load -i /tmp/workspace/box_image.tar
       - run:
           name: Run server integration tests
-          command: docker-compose -f circleci-compose.yml up --scale box=0 --exit-code-from npserver
+          command: docker-compose -f circleci-compose.yml up --scale box=0
 
   publish-latest:
     executor: docker-publisher


### PR DESCRIPTION
Remove circleci exit code check for integration tests

We no longer need to wait for an exit code on npserver because there is no Django-compiler for us to listen to anymore.